### PR TITLE
Remove requirement for order of returned objects in DependencyInjection.Tests

### DIFF
--- a/src/DependencyInjection/DI.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
+++ b/src/DependencyInjection/DI.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
@@ -730,6 +730,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             var serviceProvider = CreateServiceProvider(serviceCollection);
 
             var enumerable = serviceProvider.GetService<IEnumerable<IFakeOpenGenericService<PocoClass>>>().ToArray();
+            var service = serviceProvider.GetService<IFakeOpenGenericService<PocoClass>>();
 
             // Assert
             Assert.Equal(3, enumerable.Length);
@@ -737,8 +738,8 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             Assert.NotNull(enumerable[1]);
             Assert.NotNull(enumerable[2]);
 
-            Assert.Equal(instance, enumerable[2]);
-            Assert.IsType<FakeService>(enumerable[0]);
+            Assert.Contains(instance, enumerable);
+            Assert.Equal(instance, service);
         }
 
         [Theory]


### PR DESCRIPTION
Unity container fails [ResolvesMixedOpenClosedGenericsAsEnumerable](https://github.com/aspnet/Extensions/blob/0aa6213e1c4abd0cf45189e93751bf38b9f8c07c/src/DependencyInjection/DI.Specification.Tests/src/DependencyInjectionSpecificationTests.cs#L719) test. The test expects enumerable to have elements in the order consistent with the order of descriptors in the Service Collection.

Unity unable to keep the same order because it stores constructable types and generic type definitions in different repositories. As a result, relations between these mixed types are lost once types are registered.

I am proposing to change the check to verify existence of the instance in the returned collection and perhaps verify default resolve as well.

 
